### PR TITLE
use setting text in language

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -25,7 +25,7 @@
 					<% } else { %>
 					<form class="search" action="//google.com/search" method="get" accept-charset="utf-8">
 						<label>Search</label>
-						<input type="search" id="search" name="q" autocomplete="off" maxlength="20" placeholder="Search" />
+						<input type="search" id="search" name="q" autocomplete="off" maxlength="20" placeholder="<%= __('search') %>" />
 						<input type="hidden" name="q" value="site:<%- config.url.replace(/^https?:\/\//, '') %>">
 					</form>
 					<% } %>


### PR DESCRIPTION
I set language to `zh-CN`,the search box still show placeholder text `search`.
Maybe it's a mistake,so change it to `<%= __('search') %>`
