### PR TITLE
fix the error when using 'hexo g' by adding double quotes in yml file

### DIFF
--- a/languages/default.yml
+++ b/languages/default.yml
@@ -1,18 +1,18 @@
 categories: Categories
 search: Search
 tags: Tags
-tagcloud: Tag Cloud
+tagcloud: "Tag Cloud"
 prev: Prev
 next: Next
 comment: Comments
 contents: Contents
 archive_a: Archives
-archive_b: Archives: %s
-page: Page %d
-recent_posts: Recent Posts
+archive_b: "Archives: %s"
+page: "Page %d"
+recent_posts: "Recent Posts"
 menu: Menu
 links: Links
 rss: RSS
-showsidebar: Show Sidebar
-hidesidebar: Hide Sidebar
+showsidebar: "Show Sidebar"
+hidesidebar: "Hide Sidebar"
 updated: Updated


### PR DESCRIPTION
### Original error log

[error] { name: 'HexoError',
  reason: 'incomplete explicit mapping pair; a key node is missed',
  mark: 
   { name: null,
     buffer: 'categories: Categories\nsearch: Search\ntags: Tags\ntagcloud: Tag Cloud\nprev: Prev\nnext: Next\ncomment: Comments\ncontents: Contents\narchive_a: Archives\narchive_b: Archives: %s\npage: Page %d\nrecent_posts: Recent Posts\nmenu: Menu\nlinks: Links\nrss: RSS\nshowsidebar: Show Sidebar\nhidesidebar: Hide Sidebar\nupdated: Updated\n\u0000',
     position: 167,
     line: 9,
     column: 19 },
  message: 'Process failed: languages/default.yml',
  domain: 
   { domain: null,
     _events: { error: [Function] },
     _maxListeners: 10,
     members: [ [Object] ] },
  domainThrown: true,
  stack: undefined }
### My versions

hexo: 2.8.1
os: Darwin 13.3.0 darwin x64
http_parser: 1.0
node: 0.10.29
v8: 3.14.5.9
ares: 1.9.0-DEV
uv: 0.10.27
zlib: 1.2.3
modules: 11
openssl: 1.0.1h
