### PR TITLE
fix RSS auto-discovery <link> element

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -42,7 +42,7 @@
       <% } %>
     <% } %>
     <% if (theme.rss){ %>
-    <link rel="alternative" href="<%- theme.rss %>" title="<%= config.title %>" type="application/atom+xml">
+    <link rel="alternate" href="<%- theme.rss %>" title="<%= config.title %>" type="application/atom+xml">
     <% } %>
     <% if (theme.favicon){ %>
     <link rel="icon" href="<%- config.root %><%- theme.favicon %>">


### PR DESCRIPTION
The rel attribute MUST have a value of "alternate"
