### PR TITLE
Fix: wrong hrefs when blog root is not "/"

### DIFF
--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -13,7 +13,7 @@
 			<nav class="animated">
 				<ul>
 					<% for (var i in theme.menu){ %>
-						<li><a href="<%- theme.menu[i] %>"><%= i %></a></li>
+						<li><a href="<%- config.root %><%- theme.menu[i] %>"><%= i %></a></li>
 					<% } %>
 					<li>
 					<% if	(theme.google_cse&&theme.google_cse.enable){ %>

--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -5,6 +5,7 @@
 <% if (page.total > 1){ %>
   <nav id="page-nav" class="clearfix">
     <%- paginator({
+      base: config.root,
       prev_text: '&laquo; Prev',
       next_text: 'Next &raquo;'
     }) %>


### PR DESCRIPTION
Fix two wrong hrefs: theme menu and paginator
